### PR TITLE
Adds support for dynamic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ ng-annotate supports ES5 as input so run it with the output from Babel, Traceur,
 TypeScript (tsc) and the likes. Use `"ngInject"` on functions you want annotated.
 Your transpiler should preserve directive prologues, if not please file a bug on it.
 
+## Dynamic Imports
+If you use webpack or similar module loader you would probably like to compile to `esnext` modules
+for dynamic import support. To do that you will need to pass the `dynamicImport` flag which will switch
+from the default acorn package, to the upgraded `acorn-dynamic-import`.
 
 ## Highly recommended: enable ng-strict-di
 `<div ng-app="myApp" ng-strict-di>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,17 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+    },
+    "acorn-dynamic-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "requires": {
+        "acorn": "5.2.1"
+      }
     },
     "alter": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "acorn": "^5.0.3",
+    "acorn-dynamic-import": "^3.0.0",
     "alter": "^0.2.0",
     "convert-source-map": "^1.1.2",
     "optimist": "^0.6.1",

--- a/src/lut.js
+++ b/src/lut.js
@@ -9,7 +9,7 @@ const traverse = require("./traverse");
 const is = require("simple-is");
 
 module.exports = class Lut {
-    constructor(ast, src) {
+    constructor(ast, src, pluginOptions = {}) {
         const sparseBegins = new Array(src.length);
         const begins = [];
         const sparseEnds = new Array(src.length);
@@ -29,7 +29,7 @@ module.exports = class Lut {
             if (!sparseEnds[p]) {
                 sparseEnds[p] = node;
             }
-        }});
+        }}, pluginOptions);
         for (let i in sparseBegins) {
             begins.push(sparseBegins[i]);
         }

--- a/src/scopetools.js
+++ b/src/scopetools.js
@@ -14,8 +14,8 @@ module.exports = {
     isReference: isReference,
 };
 
-function setupScopeAndReferences(root) {
-    traverse(root, {pre: createScopes});
+function setupScopeAndReferences(root, pluginOptions = {}) {
+    traverse(root, {pre: createScopes}, pluginOptions);
     createTopScope(root.$scope);
 }
 

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -1,9 +1,11 @@
 // traverse.js
 // MIT licensed, see LICENSE file
 
-const walk = require("acorn/dist/walk");
+const defaultWalk = require("acorn/dist/walk");
+const dynamicImportWalk = require("acorn-dynamic-import/lib/walk").inject(defaultWalk);
 
-module.exports = function traverse(rootNode, options) {
+module.exports = function traverse(rootNode, options, pluginOptions = {}) {
+    const walk = pluginOptions.dynamicImport ? dynamicImportWalk : defaultWalk;
     const ancestors = [];
     (function c(node, st, override) {
         const parent = ancestors[ancestors.length - 1];

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -102,6 +102,10 @@ function run(ngAnnotate) {
     const annotated = ngAnnotate(original, {add: true}).src;
     test(slurp("tests/with_annotations.js"), annotated, "with_annotations.js");
 
+    console.log("testing adding annotations with dynamicImport enabled");
+    const annotatedWithDynamicImportEnabled = ngAnnotate(original, {add: true, dynamicImport: true}).src;
+    test(slurp("tests/with_annotations.js"), annotatedWithDynamicImportEnabled, "with_annotations.js");
+
     const rename = slurp("tests/rename.js");
 
     console.log("testing adding annotations and renaming");


### PR DESCRIPTION
Another simpler option would be to just use the new patched version of acorn always and not require an option to trigger it, but I wanted to start with this version incase people had concern with forcing the new version on existing users. 

Closes: #6 