### PR TITLE
updates readme reference for install of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ de-annotate an existing codebase that came with checked-in annotations
 ## Installation and usage
 
 ```bash
-npm install -g ng-annotate
+npm install -g ng-annotate-patched
 ```
 
 Then run it as `ng-annotate OPTIONS <file>`. The errors (if any) will go to stderr,


### PR DESCRIPTION
`npm install ng-annotate-patched`, as this looks to not have the same name as the forked source

ref: [npm: ng-annotate-patched](http://npm.im/ng-annotate-patched)