### PR TITLE
Es6 class support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,11 @@ incorrectly (a "false positive"). They are called `/*@ngNoInject*/`, `ngNoInject
 and `"ngNoInject"` and do exactly what you think they do.
 
 
-## ES6 and TypeScript support
-ng-annotate supports ES5 as input so run it with the output from Babel, Traceur,
+## ES6 support
+ES6 class syntax is supported with use of `/*@ngInject*/` and `"ngInject"` annotations. For more information please see [ES6 test file](tests/es6-classes.js).
+
+## Typescript and other transpilers support
+ng-annotate supports ES6 and below as input so run it with the output from Babel, Traceur,
 TypeScript (tsc) and the likes. Use `"ngInject"` on functions you want annotated.
 Your transpiler should preserve directive prologues, if not please file a bug on it.
 

--- a/src/nginject.js
+++ b/src/nginject.js
@@ -12,8 +12,12 @@ module.exports = {
 function inspectNode(node, ctx) {
     if (node.type === "CallExpression") {
         inspectCallExpression(node, ctx);
+    } else if (node.$parent && node.$parent.type === "MethodDefinition") {
+        // Ignore method function, constructor is processed below
     } else if (node.type === "FunctionExpression" || node.type === "FunctionDeclaration") {
         inspectFunction(node, ctx);
+    } else if (node.type === "MethodDefinition" && node.kind === 'constructor') {
+        inspectConstructor(node, ctx);
     }
 }
 
@@ -74,6 +78,17 @@ function inspectFunction(node, ctx) {
     } else {
         addSuspect(node, ctx, block);
     }
+}
+
+function inspectConstructor(node, ctx) {
+    const constructorFn = node.value;
+    const str = matchPrologueDirectives(ngAnnotatePrologueDirectives, constructorFn);
+    if (!str) {
+        return;
+    }
+    const block = (str === "ngNoInject");
+
+    addSuspect(node, ctx, block);
 }
 
 function matchPrologueDirectives(prologueDirectives, node) {

--- a/tests/es6-classes.annotated.js
+++ b/tests/es6-classes.annotated.js
@@ -1,0 +1,84 @@
+// issue #3 (ng-annotate-patched) - Support for ES6 Classes
+
+(function(){
+  class ClassTest1 {
+    constructor($log) {}
+  }
+  /** @ngInject */
+  class ClassTest1_noargs {
+    constructor() {}
+  }
+  /** @ngInject */
+  class ClassTest1_annotated {
+    constructor($log) {}
+  }
+  ClassTest1_annotated.$inject = ["$log"];
+  class ClassTest1_annotated_constructor {
+    /** @ngInject */
+    constructor($log) {}
+  }
+  ClassTest1_annotated_constructor.$inject = ["$log"];
+  class ClassTest1_prologue_directive {
+    constructor($log) {
+      "ngInject";
+    }
+  }
+  ClassTest1_prologue_directive.$inject = ["$log"];
+
+  let ClassTest2 = class {
+    constructor($log) {}
+  };
+  /** @ngInject */
+  let ClassTest2_noargs = class {
+    constructor() {}
+  };
+  /** @ngInject */
+  let ClassTest2_annotated = class {
+    constructor($log) {}
+  };
+  ClassTest2_annotated.$inject = ["$log"];
+  let ClassTest2_annotated_expression = /** @ngInject */ ["$log", class {
+    constructor($log) {}
+  }];
+  let ClassTest2_annotated_constructor = ["$log", class {
+    /** @ngInject */
+    constructor($log) {}
+  }];
+  let ClassTest2_prologue_directive = ["$log", class {
+    constructor($log) {
+      "ngInject";
+    }
+  }];
+
+  let ClassTest3,
+      ClassTest3_noargs,
+      ClassTest3_annotated,
+      ClassTest3_annotated_expression,
+      ClassTest3_annotated_constructor,
+      ClassTest3_prologue_directive;
+
+  ClassTest3 = class {
+    constructor($log) {}
+  };
+  /** @ngInject */
+  ClassTest3_noargs = class {
+    constructor() {}
+  };
+  /** @ngInject */
+  ClassTest3_annotated = class {
+    constructor($log) {}
+  };
+  ClassTest3_annotated.$inject = ["$log"];
+  ClassTest3_annotated_expression = /** @ngInject */ ["$log", class {
+    constructor($log) {}
+  }];
+  ClassTest3_annotated_constructor = ["$log", class {
+    /** @ngInject */
+    constructor($log) {}
+  }];
+  ClassTest3_prologue_directive = ["$log", class {
+    constructor($log) {
+      "ngInject";
+    }
+  }];
+})();

--- a/tests/es6-classes.js
+++ b/tests/es6-classes.js
@@ -1,0 +1,79 @@
+// issue #3 (ng-annotate-patched) - Support for ES6 Classes
+
+(function(){
+  class ClassTest1 {
+    constructor($log) {}
+  }
+  /** @ngInject */
+  class ClassTest1_noargs {
+    constructor() {}
+  }
+  /** @ngInject */
+  class ClassTest1_annotated {
+    constructor($log) {}
+  }
+  class ClassTest1_annotated_constructor {
+    /** @ngInject */
+    constructor($log) {}
+  }
+  class ClassTest1_prologue_directive {
+    constructor($log) {
+      "ngInject";
+    }
+  }
+
+  let ClassTest2 = class {
+    constructor($log) {}
+  };
+  /** @ngInject */
+  let ClassTest2_noargs = class {
+    constructor() {}
+  };
+  /** @ngInject */
+  let ClassTest2_annotated = class {
+    constructor($log) {}
+  };
+  let ClassTest2_annotated_expression = /** @ngInject */ class {
+    constructor($log) {}
+  };
+  let ClassTest2_annotated_constructor = class {
+    /** @ngInject */
+    constructor($log) {}
+  };
+  let ClassTest2_prologue_directive = class {
+    constructor($log) {
+      "ngInject";
+    }
+  };
+
+  let ClassTest3,
+      ClassTest3_noargs,
+      ClassTest3_annotated,
+      ClassTest3_annotated_expression,
+      ClassTest3_annotated_constructor,
+      ClassTest3_prologue_directive;
+
+  ClassTest3 = class {
+    constructor($log) {}
+  };
+  /** @ngInject */
+  ClassTest3_noargs = class {
+    constructor() {}
+  };
+  /** @ngInject */
+  ClassTest3_annotated = class {
+    constructor($log) {}
+  };
+  ClassTest3_annotated_expression = /** @ngInject */ class {
+    constructor($log) {}
+  };
+  ClassTest3_annotated_constructor = class {
+    /** @ngInject */
+    constructor($log) {}
+  };
+  ClassTest3_prologue_directive = class {
+    constructor($log) {
+      "ngInject";
+    }
+  };
+})();

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -187,6 +187,12 @@ function run(ngAnnotate) {
     console.log("testing optionals/angular-dashboard-framework.js (removing annotations)");
     test(adf, ngAnnotate(adfAnnotated, {remove: true, plugin: [ngAnnotateAdfPlugin]}).src, "optionals/angular-dashboard-framework.js");
 
+    // issue #3 (ng-annotate-patched) - Support for ES6 Classes
+    console.log("testing es6 classes");
+    const es6Classes = slurp("tests/es6-classes.js");
+    const es6ClassesAnnotated = ngAnnotate(es6Classes, {add: true}).src;
+    test(slurp("tests/es6-classes.annotated.js"), es6ClassesAnnotated, "tests/es6-classes.annotated.js");
+
     console.log("testing performance");
     const ng1 = String(fs.readFileSync("tests/angular.js"));
     const ng5 = ng1 + ng1 + ng1 + ng1 + ng1;


### PR DESCRIPTION
Continuation of @nevcos work on #5:

- fixed ES6 feature (which stopped working after merge with current master),
- fixed an expected result file from test suite case,
- simplified functions which return interimSuspects.