### PR TITLE
Add newer Node.js versions to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "6.0"
+  - "8.0"
+  - "10.0"
+  - "12.0"


### PR DESCRIPTION
Closes #16 

Added Node.js versions 8 & 10 (LTS) and 12 (current)