### PR TITLE
Skip createScope on catch without argument

### DIFF
--- a/src/scopetools.js
+++ b/src/scopetools.js
@@ -100,13 +100,18 @@ function createScopes(node, parent) {
         });
 
     } else if (node.type === "CatchClause") {
-        const identifier = node.param;
-
         node.$scope = new Scope({
             kind: "catch-block",
             node: node,
             parent: parent.$scope,
         });
+
+        const identifier = node.param;
+        
+        if (identifier === null) {
+            return;
+        }
+
         node.$scope.add(identifier.name, "caught", identifier, null);
 
         // All hoist-scope keeps track of which variables that are propagated through,

--- a/tests/original.js
+++ b/tests/original.js
@@ -1069,3 +1069,13 @@ const copyObj = { ...obj };
 async function foo(foo) {
     await bar();
 }
+
+// issue #21 - try catch without an argument
+// @ngInject
+export function trycatch(foo) {
+    try {
+        foo();
+    } catch {
+        // empty
+    }
+}

--- a/tests/with_annotations.js
+++ b/tests/with_annotations.js
@@ -1118,3 +1118,14 @@ const copyObj = { ...obj };
 async function foo(foo) {
     await bar();
 }
+
+// issue #21 - try catch without an argument
+// @ngInject
+export function trycatch(foo) {
+    try {
+        foo();
+    } catch {
+        // empty
+    }
+}
+trycatch.$inject = ["foo"];


### PR DESCRIPTION
Fixes https://github.com/bluetech/ng-annotate-patched/issues/20

I'm not sure if it's the right solution, but it seems to work for my end.